### PR TITLE
Only support modern Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 
 rvm:
-  - 2.3.7
-  - 2.4.5
-  - 2.5.3
+  - 2.4
+  - 2.5
+  - 2.6
 
 branches:
   only:

--- a/mvz-ruby-handlebars.gemspec
+++ b/mvz-ruby-handlebars.gemspec
@@ -4,7 +4,9 @@ Gem::Specification.new do |s|
   s.name = 'mvz-ruby-handlebars'
   s.version = '0.0.6'
 
-  s.required_rubygems_version = Gem::Requirement.new('>= 0')
+  s.rubygems_version = '>= 1.6.1'
+  s.required_ruby_version = '>= 2.4'
+
   s.authors = ['Vincent Pretre', 'Hiptest R&D', 'Matijs van Zuijlen']
   s.date = '2019-05-13'
   s.email = 'matijs@matijs.net'


### PR DESCRIPTION
- Build on 2.4, 2.5 and 2.6
- Explicitely require Ruby 2.4+
- Require 'modern' Rubygems version