### PR TITLE
Create separate context for each template evaluation

### DIFF
--- a/lib/ruby-handlebars.rb
+++ b/lib/ruby-handlebars.rb
@@ -1,16 +1,15 @@
-require_relative 'ruby-handlebars/parser'
-require_relative 'ruby-handlebars/tree'
-require_relative 'ruby-handlebars/template'
 require_relative 'ruby-handlebars/helper'
+require_relative 'ruby-handlebars/context'
+require_relative 'ruby-handlebars/parser'
+require_relative 'ruby-handlebars/template'
+require_relative 'ruby-handlebars/tree'
 
 module Handlebars
   class Handlebars
-    include Context
-
     def initialize
       @helpers = {}
       @partials = {}
-      @locals = {}
+
       register_default_helpers
     end
 
@@ -32,10 +31,6 @@ module Handlebars
 
     def get_partial(name)
       @partials[name.to_s]
-    end
-
-    def set_context(ctx)
-      @data = ctx
     end
 
     private

--- a/lib/ruby-handlebars/context.rb
+++ b/lib/ruby-handlebars/context.rb
@@ -1,5 +1,11 @@
 module Handlebars
-  module Context
+  class Context
+    def initialize(hbs, data)
+      @hbs = hbs
+      @locals = {}
+      @data = data
+    end
+
     def get(path)
       items = path.split('.'.freeze)
 
@@ -13,6 +19,14 @@ module Handlebars
       end
 
       current
+    end
+
+    def get_helper(name)
+      @hbs.get_helper(name)
+    end
+
+    def get_partial(name)
+      @hbs.get_partial(name)
     end
 
     def add_item(key, value)

--- a/lib/ruby-handlebars/template.rb
+++ b/lib/ruby-handlebars/template.rb
@@ -8,11 +8,13 @@ module Handlebars
     end
 
     def call(args = nil)
-      if args
-        @hbs.set_context(args)
-      end
+      ctx = Context.new(@hbs, args)
 
-      @ast.eval(@hbs)
+      @ast.eval(ctx)
+    end
+
+    def call_with_context(ctx)
+      @ast.eval(ctx)
     end
   end
 end

--- a/lib/ruby-handlebars/tree.rb
+++ b/lib/ruby-handlebars/tree.rb
@@ -1,3 +1,5 @@
+require 'parslet'
+
 module Handlebars
   module Tree
     class TreeItem < Struct
@@ -44,7 +46,7 @@ module Handlebars
 
     class Partial < TreeItem.new(:partial_name)
       def _eval(context)
-        context.get_partial(partial_name.to_s).call
+        context.get_partial(partial_name.to_s).call_with_context(context)
       end
     end
 


### PR DESCRIPTION
Creates a fresh context for each top-level template evaluation. This allows conflict-free concurrent and sequential evaluation with the same compiled template.