### PR TITLE
Make helpers with only optional arguments work in replacement form

### DIFF
--- a/lib/ruby-handlebars/tree.rb
+++ b/lib/ruby-handlebars/tree.rb
@@ -17,7 +17,7 @@ module Handlebars
     class Replacement < TreeItem.new(:item)
       def _eval(context)
         helper = context.get_helper(item.to_s)
-        if helper && helper.arity == 1
+        if helper && (helper.arity == 1 || helper.arity == -2)
           helper.apply(context)
         else
           context.get(item.to_s)

--- a/spec/handlebars_spec.rb
+++ b/spec/handlebars_spec.rb
@@ -117,6 +117,11 @@ describe Handlebars::Handlebars do
         expect(evaluate("{{{add left '&' right}}}", {left: 'Law', right: 'Order'})).to eq("Law & Order")
       end
 
+      it 'with optional arguments not specified' do
+        hbs.register_helper('rainbow') {|context, *opts| "-"}
+        expect(evaluate("{{rainbow}}")).to eq("-")
+      end
+
       it 'with an empty string argument' do
         hbs.register_helper('noah') {|context, value| value.to_s.gsub(/a/, '')}
 


### PR DESCRIPTION
A helper 'foo' with only optional arguments should also work when called as '{{foo}}'. To this end, allow an arity of -2 for the helper.
