### PR TITLE
Support Ruby 3.1 through 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 # Spec describe blocks and gem specification blocks can be any size
 Metrics/BlockLength:

--- a/mvz-ruby-handlebars.gemspec
+++ b/mvz-ruby-handlebars.gemspec
@@ -10,9 +10,11 @@ Gem::Specification.new do |spec|
 
   spec.summary = "Pure Ruby library for Handlebars templates"
   spec.homepage = "https://github.com/mvz/ruby-handlebars"
-  spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0.0"
 
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.1.0"
+
+  spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.extra_rdoc_files = [


### PR DESCRIPTION
This drops support for Ruby 3.0 which is EOL.
